### PR TITLE
Simplify RPM dependencies

### DIFF
--- a/bin/make-rpms.sh
+++ b/bin/make-rpms.sh
@@ -26,6 +26,8 @@ fi
 target_dir="/tftpboot/centos-6.5/ocb-packages"
 
 mkdir -p "$target_dir"
+rm -rf "$target_dir/"*.rpm "$target_dir/repodata"
 find /rpmbuild/RPMS -name '*.rpm' -exec mv '{}' "$target_dir" ';'
 (cd "$target_dir"; createrepo .)
+chown -R crowbar:crowbar "$target_dir"
 echo "Built RPMs are in \$HOME/.cache/opencrowbar/tftpboot/centos-6.5/ocb-packages"

--- a/pkginfo/opencrowbar-build-tools.spec.template
+++ b/pkginfo/opencrowbar-build-tools.spec.template
@@ -15,10 +15,7 @@ Url:      http://wwww.opencrowbar.org
 Group:    System/Management
 Source:   %{name}-%{version}.tgz
 #Patch:
-Requires: ruby >= 1.9
-#BuildRequires: 
-#PreReq:
-#Provides:
+Requires: opencrowbar-core
 BuildRoot:  %{_tmppath}/%{name}-%{version}-build
 BuildArch:  noarch
 

--- a/pkginfo/opencrowbar-ceph.spec.template
+++ b/pkginfo/opencrowbar-ceph.spec.template
@@ -14,11 +14,7 @@ Summary:  OpenCrowbar is a Hardware Provisioner and Software Deployment Tool
 Url:      http://wwww.opencrowbar.org
 Group:    system/management
 Source:   %{name}-%{version}.tgz
-#Patch:
 Requires: opencrowbar-core
-#BuildRequires: 
-#PreReq:
-#Provides:
 BuildRoot:  %{_tmppath}/%{name}-%{version}-build
 BuildArch:  noarch
 

--- a/pkginfo/opencrowbar-core.spec.template
+++ b/pkginfo/opencrowbar-core.spec.template
@@ -14,11 +14,6 @@ Summary:  OpenCrowbar is a Hardware Provisioner and Software Deployment Tool
 Url:      http://wwww.opencrowbar.org
 Group:    system/management
 Source:   %{name}-%{version}.tgz
-#Patch:
-Requires: ruby >= 1.9
-#BuildRequires:
-#PreReq:
-#Provides:
 BuildRoot:  %{_tmppath}/%{name}-%{version}-build
 BuildArch:  noarch
 

--- a/pkginfo/opencrowbar-hadoop.spec.template
+++ b/pkginfo/opencrowbar-hadoop.spec.template
@@ -14,12 +14,7 @@ Summary:  OpenCrowbar is a Hardware Provisioner and Software Deployment Tool
 Url:      http://wwww.opencrowbar.org
 Group:    system/management
 Source:   %{name}-%{version}.tgz
-#Patch:
-Requires: ruby >= 1.9
 Requires: opencrowbar-core
-#BuildRequires: 
-#PreReq:
-#Provides:
 BuildRoot:  %{_tmppath}/%{name}-%{version}-build
 BuildArch:  noarch
 

--- a/pkginfo/opencrowbar-hardware.spec.template
+++ b/pkginfo/opencrowbar-hardware.spec.template
@@ -14,12 +14,7 @@ Summary:  OpenCrowbar is a Hardware Provisioner and Software Deployment Tool
 Url:      http://wwww.opencrowbar.org
 Group:    system/management
 Source:   %{name}-%{version}.tgz
-#Patch:
-Requires: ruby >= 1.9
 Requires: opencrowbar-core
-#BuildRequires: 
-#PreReq:
-#Provides:
 BuildRoot:  %{_tmppath}/%{name}-%{version}-build
 BuildArch:  noarch
 

--- a/pkginfo/opencrowbar-openstack.spec.template
+++ b/pkginfo/opencrowbar-openstack.spec.template
@@ -14,12 +14,7 @@ Summary:  OpenCrowbar is a Hardware Provisioner and Software Deployment Tool
 Url:      http://wwww.opencrowbar.org
 Group:    system/management
 Source:   %{name}-%{version}.tgz
-#Patch:
-Requires: ruby >= 1.9
 Requires: opencrowbar-core
-#BuildRequires: 
-#PreReq:
-#Provides:
 BuildRoot:  %{_tmppath}/%{name}-%{version}-build
 BuildArch:  noarch
 

--- a/pkginfo/opencrowbar-template.spec.template
+++ b/pkginfo/opencrowbar-template.spec.template
@@ -14,12 +14,7 @@ Summary:  OpenCrowbar is a Hardware Provisioner and Software Deployment Tool
 Url:      http://wwww.opencrowbar.org
 Group:    system/management
 Source:   %{name}-%{version}.tgz
-#Patch:
-Requires: ruby >= 1.9
-Requires:  opencrowbar-core
-#BuildRequires: 
-#PreReq:
-#Provides:
+Requires: opencrowbar-core
 BuildRoot:  %{_tmppath}/%{name}-%{version}-build
 BuildArch:  noarch
 


### PR DESCRIPTION
This cuts out all the ruby prereqs, as they will be handled by the bootstrapping process.  It also updates make-rpms.sh to always build a clean repository from scratch.
